### PR TITLE
Set Node.js version to 22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,9 @@
         "eslint-config-next": "14.2.14",
         "prettier": "^3.3.3",
         "typescript": "^5"
+      },
+      "engines": {
+        "node": "22"
       }
     },
     "node_modules/@antfu/install-pkg": {

--- a/package.json
+++ b/package.json
@@ -32,5 +32,11 @@
     "eslint-config-next": "14.2.14",
     "prettier": "^3.3.3",
     "typescript": "^5"
+  },
+  "volta": {
+    "node": "22.9.0"
+  },
+  "engines": {
+    "node": "22"
   }
 }


### PR DESCRIPTION
## Description:
This PR sets Node.js version to 22 to ensure consistency across environments.

- Added Node.js version 22 using Volta in `package.json`
- Specified the engine version in `package.json` for Node.js
