### PR TITLE
Add container configuration to emulate local static hosting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:22 AS build
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm install --frozen-lockfile
+
+COPY . .
+
+RUN npm run build
+
+FROM nginx:stable-alpine AS production
+
+COPY --from=build /app/out /usr/share/nginx/html
+
+COPY nginx.conf /etc/nginx/nginx.conf
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  web:
+    build: .
+    ports:
+      - '80:80'

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,48 @@
+worker_processes auto;
+
+
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+
+
+events {
+    worker_connections 1024;  
+}
+
+
+http {
+    include /etc/nginx/mime.types;  
+    default_type application/octet-stream;
+
+    access_log /var/log/nginx/access.log combined;
+
+    sendfile on;
+    keepalive_timeout 65;
+
+    gzip on;
+    gzip_types text/css application/javascript image/svg+xml;
+
+    
+    server {
+        listen 80;  
+        server_name localhost;  
+
+        root /usr/share/nginx/html;
+        index index.html;  
+
+        location / {
+            try_files $uri $uri/ /index.html;  
+        }
+
+        error_page 404 /404.html;
+        location = /404.html {
+            internal;
+        }
+
+        location ~* \.(css|js|jpg|jpeg|png|gif|ico|svg)$ {
+            expires 1M;
+            access_log off;
+            add_header Cache-Control "public";
+        }
+    }
+}


### PR DESCRIPTION
This update adds a container configuration that mimics local static hosting.

The Dockerfile builds a static Next.js site using Node.js and creates an image that serves the site via NginX.