### PR TITLE
Add blocks resolver and update elmethis-notion version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,9 +511,9 @@ checksum = "7c6ba7d4eec39eaa9ab24d44a0e73a7949a1095a8b3f3abb11eddf27dbb56a53"
 
 [[package]]
 name = "elmethis-notion"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3993536ccdfc53fe00273443dd3d61836f71aaf3d61a496961b50ac8359a9b86"
+checksum = "6b27f37eadcd4c5cff4a8b3a3d987496d2174478abbec9b86185486e1b266d88"
 dependencies = [
  "async-recursion",
  "dotenvy",

--- a/crates/graphql/Cargo.toml
+++ b/crates/graphql/Cargo.toml
@@ -25,4 +25,4 @@ serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
 
 tokio = { version = "1", features = ["macros"] }
-elmethis-notion = "1.0.0-alpha.1"
+elmethis-notion = "1.0.0-alpha.2"

--- a/crates/graphql/src/resolvers/blog.rs
+++ b/crates/graphql/src/resolvers/blog.rs
@@ -366,9 +366,25 @@ impl Blog {
 
         let mut client = elmethis_notion::client::Client::new(notion_token);
 
-        let blocks = client.convert_block(&self.id).await.map_err(|error| {
+        let mut blocks = client.convert_block(&self.id).await.map_err(|error| {
             async_graphql::Error::new(format!("Failed to fetch blocks: {}", error))
         })?;
+
+        for block in &mut blocks {
+            if let elmethis_notion::block::Block::ElmImage(image_block) = block {
+                for image in &client.images {
+                    let from_src = &image.src;
+                    let block_id = &image.id;
+                    let to_src = format!("/?block_id={block_id}");
+
+                    let mut src = image_block.props.src.clone();
+
+                    src = src.replace(from_src, &to_src);
+
+                    image_block.props.src = src;
+                }
+            }
+        }
 
         let blocks = serde_json::to_value(blocks).map_err(|error| {
             async_graphql::Error::new(format!("Failed to serialize blocks: {}", error))


### PR DESCRIPTION
Introduce a blocks resolver to fetch and serialize Notion blocks, enhancing the handling of block images with the updated elmethis-notion library.