### PR TITLE
Change bypass mode to always for branch restrict mutation ruleset

### DIFF
--- a/terraform/github/rulesets.tf
+++ b/terraform/github/rulesets.tf
@@ -78,7 +78,7 @@ resource "github_repository_ruleset" "branch_restrict_mutation_release" {
   bypass_actors {
     actor_id    = 5 # Admin
     actor_type  = "RepositoryRole"
-    bypass_mode = "pull_request"
+    bypass_mode = "always"
   }
 }
 


### PR DESCRIPTION
Update the bypass mode for the branch restrict mutation ruleset to always, ensuring consistent behavior for the specified actor.