### PR TITLE
Feature/glue data catalog

### DIFF
--- a/terraform/aws/athena.tf
+++ b/terraform/aws/athena.tf
@@ -1,0 +1,8 @@
+resource "aws_athena_workgroup" "default" {
+  name = "${terraform.workspace}-46ki75-web-athena-workgroup-default"
+  configuration {
+    result_configuration {
+      output_location = "s3://${aws_s3_bucket.athena.bucket}/"
+    }
+  }
+}

--- a/terraform/aws/cloudfront.tf
+++ b/terraform/aws/cloudfront.tf
@@ -192,6 +192,21 @@ resource "aws_cloudwatch_log_delivery" "cloudfront" {
   delivery_source_name     = aws_cloudwatch_log_delivery_source.cloudfront.name
   delivery_destination_arn = aws_cloudwatch_log_delivery_destination.cloudfront.arn
 
+  record_fields = [
+    "date",
+    "time",
+    "c-ip",
+    "cs-method",
+    "cs-uri-stem",
+    "sc-status",
+    "cs(Referer)",
+    "cs-uri-query",
+    "x-edge-result-type",
+    "time-taken",
+    "cs-protocol-version",
+    "sc-content-type",
+  ]
+
   s3_delivery_configuration {
     suffix_path = "/{yyyy}/{MM}/{dd}/{HH}"
   }

--- a/terraform/aws/glue.tf
+++ b/terraform/aws/glue.tf
@@ -9,7 +9,6 @@ resource "aws_glue_catalog_table" "cloudfront" {
     location      = "s3://${aws_s3_bucket.cloudfront.bucket}/"
     input_format  = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
     output_format = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
-    compressed    = false
 
     ser_de_info {
       serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
@@ -21,12 +20,7 @@ resource "aws_glue_catalog_table" "cloudfront" {
     }
 
     columns {
-      name = "x_edge_location"
-      type = "string"
-    }
-
-    columns {
-      name = "sc_bytes"
+      name = "time"
       type = "string"
     }
 
@@ -37,11 +31,6 @@ resource "aws_glue_catalog_table" "cloudfront" {
 
     columns {
       name = "cs_method"
-      type = "string"
-    }
-
-    columns {
-      name = "cs_host"
       type = "string"
     }
 
@@ -61,17 +50,7 @@ resource "aws_glue_catalog_table" "cloudfront" {
     }
 
     columns {
-      name = "cs_user_agent"
-      type = "string"
-    }
-
-    columns {
       name = "cs_uri_query"
-      type = "string"
-    }
-
-    columns {
-      name = "cs_cookie"
       type = "string"
     }
 
@@ -81,47 +60,7 @@ resource "aws_glue_catalog_table" "cloudfront" {
     }
 
     columns {
-      name = "x_edge_request_id"
-      type = "string"
-    }
-
-    columns {
-      name = "x_host_header"
-      type = "string"
-    }
-
-    columns {
-      name = "cs_protocol"
-      type = "string"
-    }
-
-    columns {
-      name = "cs_bytes"
-      type = "string"
-    }
-
-    columns {
       name = "time_taken"
-      type = "string"
-    }
-
-    columns {
-      name = "x_forwarded_for"
-      type = "string"
-    }
-
-    columns {
-      name = "ssl_protocol"
-      type = "string"
-    }
-
-    columns {
-      name = "ssl_cipher"
-      type = "string"
-    }
-
-    columns {
-      name = "x_edge_response_result_type"
       type = "string"
     }
 
@@ -131,47 +70,7 @@ resource "aws_glue_catalog_table" "cloudfront" {
     }
 
     columns {
-      name = "fle_status"
-      type = "string"
-    }
-
-    columns {
-      name = "fle_encrypted_fields"
-      type = "string"
-    }
-
-    columns {
-      name = "c_port"
-      type = "string"
-    }
-
-    columns {
-      name = "time_to_first_byte"
-      type = "string"
-    }
-
-    columns {
-      name = "x_edge_detailed_result_type"
-      type = "string"
-    }
-
-    columns {
       name = "sc_content_type"
-      type = "string"
-    }
-
-    columns {
-      name = "sc_content_len"
-      type = "string"
-    }
-
-    columns {
-      name = "sc_range_start"
-      type = "string"
-    }
-
-    columns {
-      name = "sc_range_end"
       type = "string"
     }
   }

--- a/terraform/aws/glue.tf
+++ b/terraform/aws/glue.tf
@@ -1,0 +1,178 @@
+resource "aws_glue_catalog_database" "default" {
+  name = "${terraform.workspace}-46ki75-web-glue-database-default"
+}
+resource "aws_glue_catalog_table" "cloudfront" {
+  name          = "${terraform.workspace}-46ki75-web-glue-table-cloudfront"
+  database_name = aws_glue_catalog_database.default.name
+
+  storage_descriptor {
+    location      = "s3://${aws_s3_bucket.cloudfront.bucket}/"
+    input_format  = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
+    compressed    = false
+
+    ser_de_info {
+      serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+    }
+
+    columns {
+      name = "date"
+      type = "string"
+    }
+
+    columns {
+      name = "x_edge_location"
+      type = "string"
+    }
+
+    columns {
+      name = "sc_bytes"
+      type = "string"
+    }
+
+    columns {
+      name = "c_ip"
+      type = "string"
+    }
+
+    columns {
+      name = "cs_method"
+      type = "string"
+    }
+
+    columns {
+      name = "cs_host"
+      type = "string"
+    }
+
+    columns {
+      name = "cs_uri_stem"
+      type = "string"
+    }
+
+    columns {
+      name = "sc_status"
+      type = "string"
+    }
+
+    columns {
+      name = "cs_referer"
+      type = "string"
+    }
+
+    columns {
+      name = "cs_user_agent"
+      type = "string"
+    }
+
+    columns {
+      name = "cs_uri_query"
+      type = "string"
+    }
+
+    columns {
+      name = "cs_cookie"
+      type = "string"
+    }
+
+    columns {
+      name = "x_edge_result_type"
+      type = "string"
+    }
+
+    columns {
+      name = "x_edge_request_id"
+      type = "string"
+    }
+
+    columns {
+      name = "x_host_header"
+      type = "string"
+    }
+
+    columns {
+      name = "cs_protocol"
+      type = "string"
+    }
+
+    columns {
+      name = "cs_bytes"
+      type = "string"
+    }
+
+    columns {
+      name = "time_taken"
+      type = "string"
+    }
+
+    columns {
+      name = "x_forwarded_for"
+      type = "string"
+    }
+
+    columns {
+      name = "ssl_protocol"
+      type = "string"
+    }
+
+    columns {
+      name = "ssl_cipher"
+      type = "string"
+    }
+
+    columns {
+      name = "x_edge_response_result_type"
+      type = "string"
+    }
+
+    columns {
+      name = "cs_protocol_version"
+      type = "string"
+    }
+
+    columns {
+      name = "fle_status"
+      type = "string"
+    }
+
+    columns {
+      name = "fle_encrypted_fields"
+      type = "string"
+    }
+
+    columns {
+      name = "c_port"
+      type = "string"
+    }
+
+    columns {
+      name = "time_to_first_byte"
+      type = "string"
+    }
+
+    columns {
+      name = "x_edge_detailed_result_type"
+      type = "string"
+    }
+
+    columns {
+      name = "sc_content_type"
+      type = "string"
+    }
+
+    columns {
+      name = "sc_content_len"
+      type = "string"
+    }
+
+    columns {
+      name = "sc_range_start"
+      type = "string"
+    }
+
+    columns {
+      name = "sc_range_end"
+      type = "string"
+    }
+  }
+}

--- a/terraform/aws/s3.tf
+++ b/terraform/aws/s3.tf
@@ -55,3 +55,7 @@ resource "aws_s3_bucket_policy" "cloudfront" {
     ]
   })
 }
+
+resource "aws_s3_bucket" "athena" {
+  bucket = "${terraform.workspace}-46ki75-web-s3-bucket-athena"
+}


### PR DESCRIPTION
## Overview

Set up a Glue Data Catalog for querying with Amazon Athena.

## Related Issues

N/A

## Changes

- Create a Glue Database.
- Create a Glue Table.
- Create an Athena workgroup.
- Create an S3 bucket for the Athena workgroup.
- Removed unused fields in CloudFront logs.

## Checklist

- [x] Unit tests have been added.
- [x] All unit tests pass.
- [x] Documentation has been updated if necessary.

## Additional Notes

N/A
