### PR TITLE
fix(blog): avoid serializing A2UI catalog

### DIFF
--- a/packages/web-qwik/src/components/blog/blog-article.tsx
+++ b/packages/web-qwik/src/components/blog/blog-article.tsx
@@ -1,4 +1,10 @@
-import { $, component$, useAsync$, useContext } from "@qwik.dev/core";
+import {
+  $,
+  component$,
+  noSerialize,
+  useAsync$,
+  useContext,
+} from "@qwik.dev/core";
 
 import { ElmA2ui, ElmBlockFallback, notionBlockCatalog } from "@elmethis/qwik";
 
@@ -136,7 +142,7 @@ export const BlogArticle = component$<ArticleProps>(({ slug, language }) => {
             </div>
           </Meta>
           <ElmA2ui
-            catalog={notionBlockCatalog}
+            catalog={noSerialize(notionBlockCatalog)}
             messages={surfaceToMessages(
               contents.value.surface,
               `blog-${language}-${slug}`,


### PR DESCRIPTION
## Summary
- mark the runtime-only `notionBlockCatalog` prop as non-serializable
- prevent Qwik SSR Q20 when rendering A2UI blog content

## Validation
- `pnpm --filter web-qwik run build.types`
- `pnpm --filter web-qwik run lint`