### PR TITLE
fix: preserve successful blog article status

### DIFF
--- a/packages/web-solid/src/data/blog.ts
+++ b/packages/web-solid/src/data/blog.ts
@@ -22,5 +22,5 @@ export const getBlogData = query(async (locale: Locale) => {
 export const getBlogArticle = query(async (slug: string, locale: Locale) => {
   "use server";
 
-  return getBlogContents(slug, locale);
+  return { contents: await getBlogContents(slug, locale) };
 }, "blog-article");

--- a/packages/web-solid/src/routes/[[lang]]/blog/article/[slug].tsx
+++ b/packages/web-solid/src/routes/[[lang]]/blog/article/[slug].tsx
@@ -23,57 +23,64 @@ export const route = {
 
 export default function BlogArticleRoute(props: RouteSectionProps) {
   const { locale } = useI18n();
-  const contents = createAsync(() =>
-    getBlogArticle(props.params.slug!, locale()),
+  const article = createAsync(
+    () => getBlogArticle(props.params.slug!, locale()),
+    { deferStream: true },
   );
 
   return (
     <Suspense>
-      <Show
-        when={contents()}
-        keyed
-        fallback={
-          <>
-            <HttpStatusCode code={404} text="Not Found" />
-            <Seo
-              title="Not Found"
-              locale={locale()}
-              pathname={props.location.pathname}
-              type="website"
-              noIndex
-            />
-            <h1>Not Found</h1>
-          </>
-        }
-      >
-        {(resolved) => (
-          <>
-            <Seo
-              title={resolved.meta.title}
-              description={resolved.meta.description}
-              locale={locale()}
-              pathname={props.location.pathname}
-              type="article"
-              image={ogImageUrl(resolved.meta.slug, locale())}
-              jsonLd={{
-                "@context": "https://schema.org",
-                "@type": "Article",
-                headline: resolved.meta.title,
-                description: resolved.meta.description,
-                datePublished: resolved.meta.created_at,
-                dateModified: resolved.meta.updated_at,
-                inLanguage: locale(),
-                url: absoluteUrl(props.location.pathname),
-                image: absoluteUrl(ogImageUrl(resolved.meta.slug, locale())),
-                author: {
-                  "@type": "Person",
-                  name: "Ikuma Yamashita",
-                  url: absoluteUrl("/"),
-                },
-              }}
-            />
-            <BlogArticle slug={props.params.slug!} contents={resolved} />
-          </>
+      <Show when={article()} keyed>
+        {(resolvedArticle) => (
+          <Show
+            when={resolvedArticle.contents}
+            keyed
+            fallback={
+              <>
+                <HttpStatusCode code={404} text="Not Found" />
+                <Seo
+                  title="Not Found"
+                  locale={locale()}
+                  pathname={props.location.pathname}
+                  type="website"
+                  noIndex
+                />
+                <h1>Not Found</h1>
+              </>
+            }
+          >
+            {(resolved) => (
+              <>
+                <Seo
+                  title={resolved.meta.title}
+                  description={resolved.meta.description}
+                  locale={locale()}
+                  pathname={props.location.pathname}
+                  type="article"
+                  image={ogImageUrl(resolved.meta.slug, locale())}
+                  jsonLd={{
+                    "@context": "https://schema.org",
+                    "@type": "Article",
+                    headline: resolved.meta.title,
+                    description: resolved.meta.description,
+                    datePublished: resolved.meta.created_at,
+                    dateModified: resolved.meta.updated_at,
+                    inLanguage: locale(),
+                    url: absoluteUrl(props.location.pathname),
+                    image: absoluteUrl(
+                      ogImageUrl(resolved.meta.slug, locale()),
+                    ),
+                    author: {
+                      "@type": "Person",
+                      name: "Ikuma Yamashita",
+                      url: absoluteUrl("/"),
+                    },
+                  }}
+                />
+                <BlogArticle slug={props.params.slug!} contents={resolved} />
+              </>
+            )}
+          </Show>
         )}
       </Show>
     </Suspense>

--- a/packages/web-solid/tests/ssr.spec.ts
+++ b/packages/web-solid/tests/ssr.spec.ts
@@ -144,6 +144,7 @@ describe("production SSR handler", () => {
         if (url.includes("/cache/v3/blog/list/")) {
           return Response.json([]);
         }
+        await new Promise((resolve) => setTimeout(resolve, 10));
         return Response.json({
           meta: {
             slug: "a2ui-ssr-vitest",


### PR DESCRIPTION
## Summary
- distinguish unresolved article data from resolved missing content
- defer article streaming until the lookup resolves so successful articles retain HTTP 200
- cover the production-latency SSR regression while preserving real 404 responses

## Verification
- `pnpm run build`
- `pnpm run build.types`
- `pnpm run lint`
- `pnpm run fmt.check`
- `pnpm run test.ssr`
- `pnpm run test.unit`